### PR TITLE
[FE] 모드 변경 시의 색 코드 수정

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,12 +3,23 @@
 @custom-variant dark (&:where([data-theme=dark], [data-theme=dark] *));
 
 @theme {
-  --color-pointBlue: oklch(73.55% 0.1381 256.67);
-  --color-pointPurple: oklch(57.27% 0.255 290.47);
-  --color-darkBg: oklch(28.5% 0 0);
-  --color-darkGray: oklch(58.34% 0.0039 174.39);
-  --color-lightGray: oklch(79.52% 0 0);
+  --color-commonGray: oklch(58.34% 0.0039 174.39);
 }
+
+@layer base {
+  [data-theme="light"] {
+    --color-background: oklch(100% 0 0);
+    --color-point: oklch(73.55% 0.1381 256.67);
+    --color-gray: oklch(57.27% 0 0);
+    /* -- */
+  }
+  [data-theme="dark"] {
+    --color-background: oklch(28.5% 0 0);
+    --color-point: oklch(57.27% 0.255 290.47);
+    --color-gray: oklch(79.52% 0 0);
+  }
+}
+
 .modal {
   width: 100%;
   height: 100%;

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -11,9 +11,9 @@ type ListType = "chat" | "friend" | "setting";
 const Page = () => {
   const [list, setList] = useState<ListType>("chat");
   return (
-    <div className="w-full h-full bg-black flex flex-col justify-between">
+    <div className="w-full h-full bg-blue-600 flex flex-col justify-between">
       <Header />
-      <div className="dark:bg-darkBg bg-white rounded-t-[20px]">
+      <div className="bg-point rounded-t-[20px] bg-[var(--color-background)]">
         <div className="h-[543px] w-full pt-[46px]">
           {list == "chat" && <ChatList />}
           {list == "friend" && <FriendList />}

--- a/src/app/onboarding/ProfileImg.tsx
+++ b/src/app/onboarding/ProfileImg.tsx
@@ -46,13 +46,13 @@ const ProfileImg = ({ setPage }: setPageType) => {
               className="object-cover w-[100px] h-[100px] rounded-full"
             />
           ) : (
-            <div className="w-[100px] h-[100px] rounded-full border-1 text-darkGray" />
+            <div className="w-[100px] h-[100px] rounded-full border-1 text-commonGray" />
           )}
         </div>
         <button
           type="button"
           onClick={() => fileRef.current?.click()}
-          className="flex justify-center items-center w-[54px] h-[24px] bg-[#F3F6F6] text-darkGray rounded-[20px] text-[14px]"
+          className="flex justify-center items-center w-[54px] h-[24px] bg-[#F3F6F6] text-commonGray rounded-[20px] text-[14px]"
         >
           편집
         </button>

--- a/src/components/common/SelectBtn.tsx
+++ b/src/components/common/SelectBtn.tsx
@@ -8,7 +8,7 @@ type SelectBtnProp = {
 const SelectBtn = ({ label, onClick }: SelectBtnProp) => {
   return (
     <button
-      className="flex items-center justify-center rounded-[20px] bg-pointBlue dark:bg-pointPurple text-white font-bold text-[14px] h-[24px] w-[54px]"
+      className="flex items-center justify-center rounded-[20px] bg-[var(--color-point)] text-white font-bold text-[14px] h-[24px] w-[54px]"
       onClick={onClick}
     >
       {label}

--- a/src/components/common/ToggleSwitch.tsx
+++ b/src/components/common/ToggleSwitch.tsx
@@ -5,14 +5,15 @@ import clsx from "clsx";
 type ToggleSwitchProps = {
   handleOn: () => void;
   handleOff: () => void;
+  isOn: boolean;
 };
 
-const ToggleSwitch = ({ handleOn, handleOff }: ToggleSwitchProps) => {
-  const [isOn, setIsOn] = useState(false);
+const ToggleSwitch = ({ handleOn, handleOff, isOn }: ToggleSwitchProps) => {
+  const [isToggled, setIsToggled] = useState<boolean>(isOn);
 
   const handleToggle = () => {
-    setIsOn(!isOn);
-    if (!isOn) {
+    setIsToggled(!isToggled);
+    if (!isToggled) {
       handleOn();
     } else {
       handleOff();
@@ -25,9 +26,9 @@ const ToggleSwitch = ({ handleOn, handleOff }: ToggleSwitchProps) => {
       className={clsx(
         "relative grid place-items-center w-[46px] h-[29px] rounded-full p-1 transition-colors duration-300 ml-[32px]",
         {
-          "bg-darkGray dark:bg-lightGray": isOn,
-          "bg-transparent": !isOn,
-          "border-4 border-darkGray dark:border-lightGray": true,
+          "bg-[var(--color-gray)]": isToggled,
+          "bg-transparent": !isToggled,
+          "border-4 border-[var(--color-gray)] dark:border-lightGray": true,
         }
       )}
     >
@@ -35,10 +36,10 @@ const ToggleSwitch = ({ handleOn, handleOff }: ToggleSwitchProps) => {
         className={clsx(
           "w-[15px] h-[15px] rounded-full shadow-md transition-all duration-300 absolute",
           {
-            "bg-white": isOn,
-            "bg-darkGray": !isOn,
-            "left-[calc(100%_-_1.25rem)]": isOn,
-            "left-0": !isOn,
+            "bg-white": isToggled,
+            "bg-[var(--color-gray)]": !isToggled,
+            "left-[calc(100%_-_1.25rem)]": isToggled,
+            "left-0": !isToggled,
           }
         )}
       />

--- a/src/components/home/Nav.tsx
+++ b/src/components/home/Nav.tsx
@@ -9,34 +9,31 @@ type NavProps = {
 
 const Nav = ({ setList, list }: NavProps) => {
   return (
-    <div className="w-full h-[48px] border-t-[1px] border-[#999999] flex items-center justify-center bg-white">
+    <div className="w-full h-[48px] border-t-[1px] border-[#999999] flex items-center justify-center bg-[var(--color-background)]">
       <div className="w-[301px] h-[29px] flex items-center justify-between">
-        <button
-          className={clsx({
-            "text-darkGray dark:text-lightGray": list != "chat",
-            "text-pointBlue dark:text-pointPurple": list == "chat",
-          })}
-          onClick={() => setList("chat")}
-        >
-          <IoChatbubbles className="w-[30px] h-[30px]" />
+        <button onClick={() => setList("chat")}>
+          <IoChatbubbles
+            className={clsx("w-[30px] h-[30px]", {
+              "text-[var(--color-gray)]": list != "chat",
+              "text-[var(--color-point)]": list == "chat",
+            })}
+          />
         </button>
-        <button
-          className={clsx({
-            "text-darkGray dark:text-lightGray": list != "friend",
-            "text-pointBlue dark:text-pointPurple": list == "friend",
-          })}
-          onClick={() => setList("friend")}
-        >
-          <IoPeople className="w-[30px] h-[30px]" />
+        <button onClick={() => setList("friend")}>
+          <IoPeople
+            className={clsx("w-[30px] h-[30px]", {
+              "text-[var(--color-gray)]": list != "friend",
+              "text-[var(--color-point)]": list == "friend",
+            })}
+          />
         </button>
-        <button
-          className={clsx({
-            "text-darkGray dark:text-lightGray": list != "setting",
-            "text-pointBlue dark:text-pointPurple": list == "setting",
-          })}
-          onClick={() => setList("setting")}
-        >
-          <IoSettings className="w-[30px] h-[30px]" />
+        <button onClick={() => setList("setting")}>
+          <IoSettings
+            className={clsx("w-[30px] h-[30px]", {
+              "text-[var(--color-gray)]": list != "setting",
+              "text-[var(--color-point)]": list == "setting",
+            })}
+          />
         </button>
       </div>
     </div>

--- a/src/components/modal/AccountModal.tsx
+++ b/src/components/modal/AccountModal.tsx
@@ -19,33 +19,33 @@ type AccountModalProps = {
 
 const AccountModal = ({ setModal }: AccountModalProps) => {
   return (
-    <div className="modal-content flex flex-col gap-[25px] w-[281px] py-[25px] pl-[25px] bg-white dark:bg-darkBg rounded-[12px]">
+    <div className="modal-content flex flex-col gap-[25px] w-[281px] py-[25px] pl-[25px] bg-[var(--color-background)] rounded-[12px]">
       <div
         className="flex gap-[10px] items-center"
         onClick={() => setModal("changePwModal")}
       >
-        <IoMdKey className="text-darkGray dark:text-lightGray w-[30px] h-[30px]" />
+        <IoMdKey className="text-[var(--color-gray)] w-[30px] h-[30px]" />
         <p className="font-bold"> 비밀번호 변경</p>
       </div>
       <div
         className="flex gap-[10px] items-center"
         onClick={() => setModal("randomModal")}
       >
-        <FaRandom className="text-darkGray dark:text-lightGray w-[30px] h-[30px]" />
+        <FaRandom className="text-[var(--color-gray)] w-[30px] h-[30px]" />
         <p className="font-bold"> 랜덤채팅 설정</p>
       </div>
       <div
         className="flex gap-[10px] items-center"
         onClick={() => setModal("logoutModal")}
       >
-        <MdLogout className="text-darkGray dark:text-lightGray w-[30px] h-[30px]" />
+        <MdLogout className="text-[var(--color-gray)] w-[30px] h-[30px]" />
         <p className="font-bold"> 로그아웃</p>
       </div>
       <div
         className="flex gap-[10px] items-center"
         onClick={() => setModal("quitModal")}
       >
-        <MdPersonOff className="text-darkGray dark:text-lightGray w-[30px] h-[30px]" />
+        <MdPersonOff className="text-[var(--color-gray)] w-[30px] h-[30px]" />
         <p className="font-bold"> 회원탈퇴</p>
       </div>
     </div>

--- a/src/components/modal/ChangePwModal.tsx
+++ b/src/components/modal/ChangePwModal.tsx
@@ -24,9 +24,9 @@ const ChangePwModal = () => {
   }
 
   return (
-    <div className="modal-content w-[281px] h-[335px] bg-white dark:bg-darkBg rounded-[12px]">
+    <div className="modal-content w-[281px] h-[335px] bg-[var(--color-background)] rounded-[12px]">
       <div className="flex items-center pt-[28px] pl-[25px] gap-[10px]">
-        <IoMdKey className="text-darkGray dark:text-lightGray w-[30px] h-[30px]" />
+        <IoMdKey className=" w-[30px] h-[30px]" />
         <p className="text-[20px] font-bold"> 비밀번호 변경 </p>
       </div>
       <div className="px-[25px]">

--- a/src/components/modal/LogoutModal.tsx
+++ b/src/components/modal/LogoutModal.tsx
@@ -4,7 +4,7 @@ import SelectBtn from "../common/SelectBtn";
 
 const LogoutModal = () => {
   return (
-    <div className="modal-content w-[281px] h-[139px] py-[28px] px-[22px] bg-white dark:bg-darkBg rounded-[12px]">
+    <div className="modal-content w-[281px] h-[139px] py-[28px] px-[22px] bg-[var(--color-background)] rounded-[12px]">
       <div className="flex">
         <MdLogout className="w-[30px] h-[30px] text-[#787878] dark:text-lightGray" />
         <p className="text-[20px] font-bold ml-[14px]">로그아웃하기</p>

--- a/src/components/modal/ModeModal.tsx
+++ b/src/components/modal/ModeModal.tsx
@@ -1,23 +1,37 @@
 "use client";
 import React from "react";
-import { IoMdMoon } from "react-icons/io";
+import { IoMdMoon, IoMdSunny } from "react-icons/io";
 import ToggleSwitch from "../common/ToggleSwitch";
 import { useTheme } from "next-themes";
 
 const ModeModal = () => {
-  const { setTheme } = useTheme();
+  const { theme, setTheme } = useTheme();
+
+  function isThemeDark() {
+    return theme == "dark";
+  }
 
   return (
-    <div className="modal-content w-[281px] h-[139px] py-[28px] px-[22px] bg-white dark:bg-darkBg rounded-[12px]">
+    <div className="modal-content w-[281px] h-[139px] py-[28px] px-[22px] rounded-[12px] bg-[var(--color-background)]">
       <div className="flex">
-        <IoMdMoon className="w-[30px] h-[30px] text-[#787878] dark:text-lightGray" />
+        {isThemeDark() ? (
+          <IoMdSunny className="w-[30px] h-[30px] text-[#787878] dark:text-[var(--color-gray)]" />
+        ) : (
+          <IoMdMoon className="w-[30px] h-[30px] text-[#787878] dark:text-[var(--color-gray)]" />
+        )}
         <p className="text-[20px] font-bold ml-[14px]">모드 변경</p>
       </div>
       <div className="flex mt-[28px] w-full">
-        <p className="font-semibold"> 다크 모드로 전환하기</p>
+        {isThemeDark() ? (
+          <p className="font-semibold text-[14px]"> 라이트 모드로 전환하기</p>
+        ) : (
+          <p className="font-semibold text-[14px]"> 다크 모드로 전환하기</p>
+        )}
+
         <ToggleSwitch
           handleOn={() => setTheme("dark")}
           handleOff={() => setTheme("light")}
+          isOn={isThemeDark()}
         />
       </div>
     </div>

--- a/src/components/modal/QuitModal.tsx
+++ b/src/components/modal/QuitModal.tsx
@@ -4,7 +4,7 @@ import { MdPersonOff } from "react-icons/md";
 
 const QuitModal = () => {
   return (
-    <div className="modal-content w-[281px] h-[139px] py-[28px] px-[22px] bg-white dark:bg-darkBg rounded-[12px]">
+    <div className="modal-content w-[281px] h-[139px] py-[28px] px-[22px] bg-[var(--color-background)] rounded-[12px]">
       <div className="flex">
         <MdPersonOff className="w-[30px] h-[30px] text-[#787878] dark:text-lightGray" />
         <p className="text-[20px] font-bold ml-[14px]">회원탈퇴하기</p>

--- a/src/components/modal/RandomModal.tsx
+++ b/src/components/modal/RandomModal.tsx
@@ -4,7 +4,7 @@ import { FaRandom } from "react-icons/fa";
 
 const RandomModal = () => {
   return (
-    <div className="modal-content w-[281px] h-[139px] py-[28px] px-[22px] bg-white dark:bg-darkBg rounded-[12px]">
+    <div className="modal-content w-[281px] h-[139px] py-[28px] px-[22px] bg-[var(--color-background)] rounded-[12px]">
       <div className="flex">
         <FaRandom className="w-[30px] h-[30px] text-[#787878] dark:text-lightGray" />
         <p className="text-[20px] font-bold ml-[14px]">랜덤채팅 설정</p>

--- a/src/components/setting/PwInput.tsx
+++ b/src/components/setting/PwInput.tsx
@@ -16,13 +16,13 @@ const PwInput = ({ isValid, label, value, onChange }: pwInputProp) => {
     <div
       className={clsx(" h-[50px] font-bold mt-[15px] border-b-1", {
         "border-[#C81919]": !isValid,
-        "text-black dark:text-white": isValid,
+        "": isValid,
       })}
     >
       <p
         className={clsx({
           "text-[#C81919]": !isValid,
-          "text-black dark:text-white": isValid,
+          "": isValid,
         })}
       >
         {label}

--- a/src/components/setting/SettingList.tsx
+++ b/src/components/setting/SettingList.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useState } from "react";
-import { IoMdMoon, IoMdPerson } from "react-icons/io";
+import { IoMdMoon, IoMdPerson, IoMdSunny } from "react-icons/io";
 import { PiKeyFill } from "react-icons/pi";
 import ModeModal from "../modal/ModeModal";
 import AccountModal from "../modal/AccountModal";
@@ -8,6 +8,7 @@ import ChangePwModal from "../modal/ChangePwModal";
 import QuitModal from "../modal/QuitModal";
 import LogoutModal from "../modal/LogoutModal";
 import RandomModal from "../modal/RandomModal";
+import { useTheme } from "next-themes";
 
 type modalType =
   | "modeModal"
@@ -20,11 +21,12 @@ type modalType =
 
 const SettingList = () => {
   const [modal, setModal] = useState<modalType>("none");
+  const { theme } = useTheme();
   return (
     <div>
       {modal == "none" ? null : (
         <div className="modal h-screen" onClick={() => setModal("none")}>
-          <div onClick={(e) => e.stopPropagation()} className="dark:bg-darkBg">
+          <div onClick={(e) => e.stopPropagation()}>
             {modal == "modeModal" && <ModeModal />}
             {modal == "accountModal" && <AccountModal setModal={setModal} />}
             {modal == "changePwModal" && <ChangePwModal />}
@@ -34,17 +36,17 @@ const SettingList = () => {
           </div>
         </div>
       )}
-      <div className="w-full h-[102px] px-[22px] border-b-1 border-[#F3F6F6]">
+      <div className="w-full h-[102px] px-[22px] border-b-1 border-commonGray">
         {/* 본인 프로필 */}
       </div>
       <div className="w-full px-[25px] mt-[25px] flex flex-col gap-[30px]">
         <div className="flex">
           <div className="rounded-full bg-[#F2F8F7] h-[44px] w-[44px] flex items-center justify-center">
-            <IoMdPerson className="w-[25px] h-[25px] text-[#787878] dark:text-lightGray" />
+            <IoMdPerson className="w-[25px] h-[25px] text-[#787878] dark:text-[var(--color-gray)]" />
           </div>
           <div className="ml-[12px]">
             <p className="font-semibold text-[18px]"> 프로필 설정 </p>
-            <p className="text-[12px] text-darkGray">
+            <p className="text-[12px] text-commonGray">
               이름, 한 줄 소개 등의 설정이 가능해요.
             </p>
           </div>
@@ -52,11 +54,15 @@ const SettingList = () => {
 
         <div className="flex" onClick={() => setModal("modeModal")}>
           <div className="rounded-full bg-[#F2F8F7] h-[44px] w-[44px] flex items-center justify-center">
-            <IoMdMoon className="w-[25px] h-[25px] text-[#787878] dark:text-lightGray" />
+            {theme == "light" ? (
+              <IoMdMoon className="w-[25px] h-[25px] text-[#787878] dark:text-[var(--color-gray)]" />
+            ) : (
+              <IoMdSunny className="w-[25px] h-[25px] text-[#787878] dark:text-[var(--color-gray)]" />
+            )}
           </div>
           <div className="ml-[12px]">
             <p className="font-semibold text-[18px]"> 모드 변경 </p>
-            <p className="text-[12px] text-darkGray">
+            <p className="text-[12px] text-commonGray">
               라이트모드, 다크모드로 전환할 수 있어요.
             </p>
           </div>
@@ -64,11 +70,11 @@ const SettingList = () => {
 
         <div className="flex" onClick={() => setModal("accountModal")}>
           <div className="rounded-full bg-[#F2F8F7] h-[44px] w-[44px] flex items-center justify-center">
-            <PiKeyFill className="w-[20px] h-[20px] text-[#787878] dark:text-lightGray" />
+            <PiKeyFill className="w-[20px] h-[20px] text-[#787878] dark:text-[var(--color-gray)]" />
           </div>
           <div className="ml-[12px]">
             <p className="font-semibold text-[18px]"> 게정 관리 </p>
-            <p className="text-[12px] text-darkGray">
+            <p className="text-[12px] text-commonGray">
               비밀번호 변경 등의 계정 관리가 가능해요.
             </p>
           </div>

--- a/src/components/sign/SignBtn.tsx
+++ b/src/components/sign/SignBtn.tsx
@@ -11,7 +11,7 @@ const SignBtn = ({ value, isFull, onClick }: SignBtnProps) => {
   return (
     <button
       className={clsx("w-[327px] h-[48px] rounded-[16px] border-1 mb-[49px]", {
-        "bg-white text-darkGray": isFull,
+        "bg-white text-commonGray": isFull,
         "bg-transparent text-white": !isFull,
       })}
       onClick={onClick}


### PR DESCRIPTION
## 작업 내용
 다크 모드로 변경 시 색 코드를 'dark:설정-색' 이런 식으로 따로 설정해 코드 길이가 길어졌습니다. 이를 수정하기 위해 라이트 모드의 색, 다크 모드의 색을 같은 이름으로 설정해 '요소-[var(--color-색 변수명)]' 이 되게끔 했습니다. 이제 별 다른 설정 없이도 모드 별 색이 다르게 되었습니다.

## 연관된 이슈
- #5 

## 스크린샷 (선택)

## 특이사항 (선택)
